### PR TITLE
Fix typo in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ removeArticleMutation({ // your mutation
     variables: {
         id: article.id // your mutation vars
     },
-    update: (proxy }) => {
+    update: (proxy) => {
         const updates = ApolloCacheUpdater({
             proxy, // mandatory
             queriesToUpdate: [getArticles, articlesCount], // queries you want to automatically update


### PR DESCRIPTION
I believe this closing `}` is not supposed to be there. This PR cleans it up.